### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ A curated list of cryptography resources and links.
 
 ### Scala
 
-- [scrypto](https://github.com/ScorexProject/scrypto) - Cryptographic primitives for Scala.
+- [scrypto](https://github.com/input-output-hk/scrypto) - Cryptographic primitives for Scala.
 
 ### Swift
 


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/ScorexProject/scrypto | https://github.com/input-output-hk/scrypto 
