### PR TITLE
Added Clj-crypto

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ A curated list of cryptography resources and links.
 
 ### Clojure
 
-- [clj-crypto](https://github.com/macourtney/clj-crypto/) - wrapper for Bouncy Castle.
 - [buddy-core](https://funcool.github.io/buddy-core/latest/) - Cryptographic Api.
+- [clj-crypto](https://github.com/macourtney/clj-crypto/) - Wrapper for Bouncy Castle.
 - [pandect](https://github.com/xsc/pandect) - Fast and easy-to-use Message Digest, Checksum and HMAC library for Clojure.
 
 ### Common Lisp

--- a/README.md
+++ b/README.md
@@ -162,9 +162,9 @@ A curated list of cryptography resources and links.
 
 ### Clojure
 
+- [clj-crypto](https://github.com/macourtney/clj-crypto/) - wrapper for Bouncy Castle.
 - [buddy-core](https://funcool.github.io/buddy-core/latest/) - Cryptographic Api.
 - [pandect](https://github.com/xsc/pandect) - Fast and easy-to-use Message Digest, Checksum and HMAC library for Clojure.
-- [clj-crypto](https://github.com/macourtney/clj-crypto/) - wrapper for Bouncy Castle.
 
 ### Common Lisp
 

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ A curated list of cryptography resources and links.
 
 - [buddy-core](https://funcool.github.io/buddy-core/latest/) - Cryptographic Api.
 - [pandect](https://github.com/xsc/pandect) - Fast and easy-to-use Message Digest, Checksum and HMAC library for Clojure.
+- [clj-crypto](https://github.com/macourtney/clj-crypto/) - wrapper for Bouncy Castle.
 
 ### Common Lisp
 


### PR DESCRIPTION
Added Clj-crypto, a wrapper for Bouncy Castle which allows you to easily use cryptography in your clojure app.