### PR TITLE
Adding GDH project to Java list

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ A curated list of cryptography resources and links.
 - [keywhiz](https://github.com/square/keywhiz) - A system for distributing and managing secrets.
 - [pac4j](https://github.com/pac4j/pac4j) - Security engine.
 - [scrypt](https://github.com/wg/scrypt) - Pure Java implementation of the scrypt key derivation function and a JNI interface to the C implementations, including the SSE2 optimized version.
+- [GDH](https://github.com/maxamel/GDH) - Generalized Diffie-Hellman key exchange Java library for multiple parties built on top of the Vert.x framework.
 
 ### Julia
 


### PR DESCRIPTION
Adding GDH project to Java list. The project is a Java library built on top of Vert.x to allow Generalized Diffie-Hellman key exchange between multiple participants. 