### PR TITLE
Add milagro-crypto-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ A curated list of cryptography resources and links.
 - [libsodium](https://github.com/jedisct1/libsodium) - Modern and easy-to-use crypto library.
 - [libtomcrypt](https://github.com/libtom/libtomcrypt) - Fairly comprehensive, modular and portable cryptographic toolkit.
 - [libVES.c](https://github.com/vesvault/libVES.c) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
+- [milagro-crypto-c](https://github.com/apache/incubator-milagro-crypto-c) - Small, self-contained and fast open source crypto library. It supports RSA, ECDH, ECIES, ECDSA, AES-GCM, SHA2, SHA3 and Pairing-Based Cryptography.
 - [monocypher](http://loup-vaillant.fr/projects/monocypher/) - small, portable, easy to use crypto library inspired by libsodium and TweetNaCl.
 - [NaCl](https://nacl.cr.yp.to/) - High-speed library for network communication, encryption, decryption, signatures, etc.
 - [OpenSSL](https://github.com/openssl/openssl) - TLS/SSL and crypto library.


### PR DESCRIPTION
milagro-crypto-c is an open source crypto-library supporting RSA, ECDH, ECIES, ECDSA, AES-GCM, SHA256. SHA384, SHA512, SHA3, and many protocols of Pairing-Based Cryptography such as MPIN, MPIN-FULL, and BLS signature. It is small, portable and side channel resistant, easy to build on Linux, Mac-OS and Windows.

Is a project hosted by Apache (incubator).