### PR TITLE
Add Deadhand to the list of cryptographic tools in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A curated list of cryptography resources and links.
 - [Coherence](https://github.com/liesware/coherence/) - Cryptographic server for modern web apps.
 - [cryptomator](https://github.com/cryptomator/cryptomator) - Multi-platform transparent client-side encryption of your files in the cloud.
 - [Databunker](https://databunker.org/) - API based personal data or PII storage service built to comply with GDPR and CCPA.
+- [Deadhand](https://deadhandprotocol.com/) - Dead man's switch for crypto. Splits seed phrases using Shamir's Secret Sharing (2-of-3).
 - [gpg](https://www.gnupg.org/) - Complete and free implementation of the OpenPGP standard. It allows to encrypt and sign your data and communication, features a versatile key management system. GnuPG is a command line tool with features for easy integration with other applications.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.


### PR DESCRIPTION
### Description
Added [Deadhand Protocol](https://deadhandprotocol.com) - A dead man's switch for crypto inheritance using Shamir's Secret Sharing.

### Why it belongs
- Non-custodial crypto inheritance tool
- Uses industry-standard SSS cryptography
- Source-available under BSL 1.1
- Solves a real problem (billions in lost crypto due to dead owners)