### PR TITLE
Add provara to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [hashids](https://github.com/davidaurelio/hashids-python) - Implementation of [hashids](http://hashids.org) in Python.
 - [paramiko](http://www.paramiko.org/) - Python implementation of the SSHv2 protocol, providing both client and server functionality.
 - [Privy](https://github.com/ofek/privy) - An easy, fast lib to correctly password-protect your data.
+- [provara](https://github.com/huntinformationsystems/hunt-protocol-mcp) - Tamper-evident memory protocol for AI agents using Ed25519 signatures, SHA-256 hashing, and RFC 8785 canonical JSON. MCP server with 10 tools for cryptographic vault operations.
 - [pycryptodome](https://github.com/Legrandin/pycryptodome) - Self-contained Python package of low-level cryptographic primitives.
 - [PyElliptic](https://github.com/yann2192/pyelliptic) - Python OpenSSL wrapper. For modern cryptography with ECC, AES, HMAC, Blowfish.
 - [pynacl](https://github.com/pyca/pynacl) - Python binding to the Networking and Cryptography (NaCl) library.


### PR DESCRIPTION
## Summary

- Adds [provara](https://github.com/huntinformationsystems/hunt-protocol-mcp) to the **Python** section in alphabetical order.
- Provara is a tamper-evident memory protocol for AI agents using Ed25519 signatures (RFC 8032), SHA-256 hashing (FIPS 180-4), and RFC 8785 canonical JSON serialization. It provides an MCP server with 10 tools for cryptographic vault operations. Available on [PyPI](https://pypi.org/project/provara/) as `provara`. Apache 2.0 licensed.

## Checklist

- [x] Entry is in alphabetical order within the Python section
- [x] Format matches existing entries (name, link, description)
- [x] Link points to a valid GitHub repository
- [x] Description is concise and accurate