### PR TITLE
Add Vaulted to Tools > Standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ A curated list of cryptography resources and links.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
+- [Vaulted](https://www.vaulted.fyi) - Client-side secret sharing using AES-256-GCM via Web Crypto API. Encryption key lives in URL fragment (never sent to server). Self-destructing links with view limits and optional passphrase wrapping.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
 
 ### Plugins


### PR DESCRIPTION
## What is Vaulted?

[Vaulted](https://www.vaulted.fyi) is a zero-knowledge secret sharing tool built on the Web Crypto API.

## Cryptographic details

- **Algorithm:** AES-256-GCM (client-side, via `SubtleCrypto`)
- **Key management:** Encryption key is generated in the browser and placed in the URL fragment (`#`) — it is never transmitted to the server
- **Passphrase wrapping:** Optional passphrase protection using PBKDF2-derived key wrapping
- **Architecture:** Zero-knowledge — the server stores only ciphertext, IV, and salt. It never has access to plaintext or keys.

## Features

- Self-destructing links with configurable view limits (1–10)
- Expiration up to 30 days
- CLI tool available via npm (`vaulted-cli`) using the same encryption
- No account required

## Section

Added to **Tools > Standalone**, alphabetically between `sops` and `ves`.