### PR TITLE
Add RustChain Proof-of-Antiquity to Python section

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [pycryptodome](https://github.com/Legrandin/pycryptodome) - Self-contained Python package of low-level cryptographic primitives.
 - [PyElliptic](https://github.com/yann2192/pyelliptic) - Python OpenSSL wrapper. For modern cryptography with ECC, AES, HMAC, Blowfish.
 - [pynacl](https://github.com/pyca/pynacl) - Python binding to the Networking and Cryptography (NaCl) library.
+- [RustChain](https://github.com/Scottcjn/Rustchain) - Proof-of-Antiquity consensus blockchain using Ed25519 signatures, BIP39 seed phrases, Blake2b256 commitment hashes, and hardware fingerprinting (clock drift, cache timing, SIMD profiling) for anti-emulation attestation.
 - [pythemis](https://github.com/cossacklabs/themis/wiki/Python-Howto) - Python wrapper on Themis. High level crypto library for storing data (AES), secure messaging (ECC + ECDSA / RSA + PSS + PKCS#7) and session-oriented, forward secrecy data exchange (ECDH key agreement, ECC & AES encryption).
 
 ### R


### PR DESCRIPTION
## Summary

Adds [RustChain](https://github.com/Scottcjn/Rustchain) to the Python Frameworks and Libs section.

RustChain implements several cryptographic primitives in Python:

- **Ed25519 digital signatures** via PyNaCl for transaction signing
- **BIP39 mnemonic seed phrases** (24-word) for deterministic key derivation
- **Blake2b256 commitment hashes** for on-chain anchor attestations
- **AES-256-GCM encrypted keystores** with PBKDF2 (100,000 iterations)
- **Hardware fingerprinting** using timing-based cryptographic attestation

Installable via `pip install clawrtc` (75+ stars, actively maintained).

## Why it is awesome

Combines Ed25519, Blake2b256, BIP39, and AES-256-GCM into a novel Proof-of-Antiquity consensus that uses timing-based proofs to authenticate physical hardware.