### PR TITLE
Update CrypTool link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,7 +454,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 
 - [Boxentriq](https://www.boxentriq.com/code-breaking) - Easy to use tools for analysis and code-breaking of the most frequent ciphers, including Vigenère, Beaufort, Keyed Caesar, Transposition Ciphers, etc.
 - [Cryptolab](http://manansingh.github.io/Cryptolab-Offline/cryptolab.html) - is a set of cryptography related tools.
-- [CrypTool](http://www.cryptool-online.org/) - Great variety of ciphers, encryption methods and analysis tools are introduced, often together with illustrated examples.
+- [CrypTool](https://www.cryptool.org) - Great variety of ciphers, encryption methods and analysis tools are introduced, often together with illustrated examples.
 - [CyberChef](https://gchq.github.io/CyberChef/) - a web app for encryption, encoding, compression, and data analysis.
 - [factordb.com](http://factordb.com/) - Factordb.com is tool used to store known factorizations of any number.
 - [keybase.io](https://keybase.io/) - Keybase maps your identity to your public keys, and vice versa.


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, correcting the URL for the CrypTool resource to its current and secure website.