### PR TITLE
Add UltrafastSecp256k1

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ A curated list of cryptography resources and links.
 - [HElib](https://github.com/shaih/HElib) - Software library that implements homomorphic encryption (HE).
 - [Nettle](http://www.lysator.liu.se/~nisse/nettle/) - Low-level cryptographic library.
 - [s2n](https://github.com/awslabs/s2n) - Implementation of the TLS/SSL protocols.
+- [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) - High-performance `secp256k1` engine in `C++20` with CPU, CUDA, OpenCL, embedded, WebAssembly, a stable C ABI, and broad validation tooling.
 
 ### C-sharp
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A curated list of cryptography resources and links.
 - [HElib](https://github.com/shaih/HElib) - Software library that implements homomorphic encryption (HE).
 - [Nettle](http://www.lysator.liu.se/~nisse/nettle/) - Low-level cryptographic library.
 - [s2n](https://github.com/awslabs/s2n) - Implementation of the TLS/SSL protocols.
-- [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) - High-performance `C++20` `secp256k1` engine with CPU, GPU, and WebAssembly support.
+- [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) - High-performance secp256k1 engine in C++20 with a stable C ABI.
 
 ### C-sharp
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ A curated list of cryptography resources and links.
 - [HElib](https://github.com/shaih/HElib) - Software library that implements homomorphic encryption (HE).
 - [Nettle](http://www.lysator.liu.se/~nisse/nettle/) - Low-level cryptographic library.
 - [s2n](https://github.com/awslabs/s2n) - Implementation of the TLS/SSL protocols.
-- [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) - High-performance `secp256k1` engine in `C++20` with CPU, CUDA, OpenCL, embedded, WebAssembly, a stable C ABI, and broad validation tooling.
+- [UltrafastSecp256k1](https://github.com/shrec/UltrafastSecp256k1) - High-performance `C++20` `secp256k1` engine with CPU, GPU, and WebAssembly support.
 
 ### C-sharp
 


### PR DESCRIPTION
## Summary
- add UltrafastSecp256k1 to the C++ cryptography libraries list

## Why
UltrafastSecp256k1 is a high-performance secp256k1 engine in C++20 with CPU, CUDA, OpenCL, embedded, WebAssembly, a stable C ABI, and broad validation tooling.
