### PR TITLE
Add PaperVault to Standalone tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of cryptography resources and links.
 - [gpg](https://www.gnupg.org/) - Complete and free implementation of the OpenPGP standard. It allows to encrypt and sign your data and communication, features a versatile key management system. GnuPG is a command line tool with features for easy integration with other applications.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
+- [PaperVault](https://github.com/boazeb/papervault) - Offline paper-based secret storage using AES-256-GCM encryption and Shamir's Secret Sharing for threshold key splitting.
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
 


### PR DESCRIPTION
PaperVault is an offline, client-side tool for creating paper-based encrypted backups of secrets (passwords, seed phrases, recovery codes) using AES-256-GCM and Shamir's Secret Sharing for threshold key splitting.

- Encrypts secrets and splits the decryption key into M-of-N shares
- Generates printable QR-coded vault and key documents
- Client-side only — zero network requests, designed for air-gapped use
- MIT licensed

Website: https://papervault.xyz
Source: https://github.com/boazeb/papervault