### PR TITLE
docs: add enterprise-blockchain reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A curated list of cryptography resources and links.
 - [crypto-js](https://github.com/brix/crypto-js) - JavaScript library of crypto standards.
 - [cryptojs](https://github.com/gwjjeff/cryptojs) - Provide standard and secure cryptographic algorithms for Node.js.
 - [forge](https://github.com/digitalbazaar/forge) - Native implementation of TLS in JavaScript and tools to write crypto-based and network-heavy webapps.
+- [enterprise-blockchain](https://github.com/psavelis/enterprise-blockchain) - Enterprise blockchain toolkit with NIST post-quantum crypto (ML-KEM, ML-DSA), MPC, and HSM integration.
 - [IronNode](https://docs.ironcorelabs.com/ironnode-sdk/overview) - Transform encryption library, a variant of proxy re-encryption, for encrypting to users or groups, and easily adding strong data controls to Node.js apps.
 - [IronWeb](https://docs.ironcorelabs.com/ironweb-sdk/overview) - Transform encryption library, a variant of proxy re-encryption, for easily managing end-to-end encryption securely in the browser.
 - [javascript-crypto-library](https://github.com/clipperz/javascript-crypto-library) - JavaScript Crypto Library provides web developers with an extensive and efficient set of cryptographic functions.


### PR DESCRIPTION
Hi,

  I'm the **author** and maintainer of [enterprise-blockchain](https://github.com/psavelis/enterprise-blockchain), and I'd like to propose **adding it to the JavaScript section**.

  It's a TypeScript library providing:
  - NIST FIPS 203/204 post-quantum algorithms (ML-KEM, ML-DSA)
  - MPC with additive secret sharing and Shamir threshold schemes
  - HSM integration patterns for production environments

  The library focuses on enterprise blockchain use cases with protocol adapters for Hyperledger Fabric, Besu, and Corda.

  **I understand self-submissions may require extra scrutiny, happy to provide more context or adjust the description if needed.**

  Thank you for maintaining this excellent resource.

  Best regards,
  Pedro Savelis