### PR TITLE
Add ECB Penguin to Playgrounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ A curated list of cryptography resources and links.
 
 ### Playgrounds
 
+- [ECB Penguin](https://ecb-penguin.securityronin.com/) - Interactive AES encryption demo showing why ECB mode is insecure by encrypting Linux Tux side-by-side with ECB and GCM, with decryption, bit-flip attacks, block heatmap, and a real-world TLS attack timeline.
 - [Cryptography Playground](https://vishwas1.github.io/crypto/index.html#/crypto) - A simple web tool to play and learn basic concepts of cryptography like, hashing, symmetric, asymmetric, zkp etc.
 
 ## Frameworks and Libs


### PR DESCRIPTION
## What

Adds [ECB Penguin](https://ecb-penguin.securityronin.com/) to the Playgrounds section.

## Why it's awesome

ECB Penguin is a free, interactive, zero-dependency web demo that visually demonstrates why AES-ECB mode is insecure:

- Encrypts Linux Tux with AES-ECB vs AES-GCM side by side — the penguin silhouette is preserved in ECB
- Decrypt with correct/wrong keys — ECB silently fails, GCM detects tampering
- Bit-flip attack demo — flip a ciphertext block and see ECB corrupt one block vs GCM refusing entirely
- Block heatmap overlay showing duplicate ciphertext blocks
- Interactive educational panels: block anatomy, key derivation, ECB vs GCM data flow
- Timeline of real-world attacks (BEAST, Lucky13, POODLE, GoldenDoodle) and why TLS 1.3 mandates GCM

Built with pure WebCrypto API — no dependencies, runs entirely in the browser.

Source: https://github.com/SecurityRonin/ecb-penguin