### PR TITLE
Add cert-depot to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A curated list of cryptography resources and links.
 - [Bcrypt](http://bcrypt.sourceforge.net/) - Cross-platform file encryption utility.
 - [blackbox](https://github.com/StackExchange/blackbox) - safely store secrets in Git/Mercurial/Subversion.
 - [certbot](https://github.com/certbot/certbot) - Previously the Let's Encrypt Client, is EFF's tool to obtain certs from Let's Encrypt, and (optionally) auto-enable HTTPS on your server. It can also act as a client for any other CA that uses the ACME protocol.
+- [cert-depot](https://github.com/dimastopel/certdepot) - Free self-signed certificate generator. Single Go binary, keys generated in memory and never stored.
 - [Coherence](https://github.com/liesware/coherence/) - Cryptographic server for modern web apps.
 - [cryptomator](https://github.com/cryptomator/cryptomator) - Multi-platform transparent client-side encryption of your files in the cloud.
 - [Databunker](https://databunker.org/) - API based personal data or PII storage service built to comply with GDPR and CCPA.


### PR DESCRIPTION
Add [cert-depot](https://github.com/dimastopel/certdepot) — a free, open-source self-signed SSL/TLS certificate generator.

- Written in Go, ships as a single binary with no external dependencies
- Uses Go's native crypto/x509 (no OpenSSL)
- Keys are generated in memory and streamed directly to the user — nothing is stored on the server
- Supports RSA 2048/4096, ECDSA P-256/P-384, Subject Alternative Names
- ZIP (PEM) and PFX (PKCS#12) output
- MIT licensed

Live instance: https://cert-depot.com