### PR TITLE
Add PoSME to Rust section

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [octavo](https://github.com/libOctavo/octavo) - Highly modular & configurable hash & crypto library.
 - [orion](https://github.com/orion-rs/orion) - is a cryptography library written in pure Rust. It aims to provide easy and usable crypto while trying to minimize the use of unsafe code.
 - [password-hashes](https://github.com/RustCrypto/password-hashes) - Collection of password hashing algorithms, otherwise known as password-based key derivation functions, written in pure Rust.
+- [posme](https://github.com/LF-Decentralized-Trust-labs/proof-of-effort/tree/main/impl/posme) - Proof of Sequential Memory Execution: a latency-bound memory-hard primitive via pointer chasing with causal hash binding, using BLAKE3. Provides ASIC resistance (~2x bound) and verifiable sequential proofs.
 - [proteus](https://github.com/wireapp/proteus) - Axolotl protocol implementation, without header keys, in Rust.
 - [rage](https://github.com/str4d/rage) - is a simple, modern, and secure file encryption tool, using the age format.
 - [recrypt](https://github.com/IronCoreLabs/recrypt-rs) - A pure-Rust library that implements cryptographic primitives for building a multi-hop Proxy Re-encryption scheme, known as Transform Encryption.


### PR DESCRIPTION
Adds PoSME to the Rust section. It's a memory-hard sequential proof primitive using BLAKE3 and pointer chasing over mutable memory. ASIC resistance is ~2x (vs Argon2's 8-16x) because the bottleneck is DRAM latency, not compute.

Pure Rust, Apache-2.0.