### PR TITLE
Add QuantumScan to Tools / Standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of cryptography resources and links.
 - [gpg](https://www.gnupg.org/) - Complete and free implementation of the OpenPGP standard. It allows to encrypt and sign your data and communication, features a versatile key management system. GnuPG is a command line tool with features for easy integration with other applications.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
+- [QuantumScan](https://quantumscan.io/) - Free scanner that detects RSA, ECDSA, SHA-1 and other quantum-vulnerable cryptography in GitHub repositories. Exports CycloneDX 1.7 CBOM and DORA/NIS2 compliance reports. Open-source scanner core (MIT).
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
 


### PR DESCRIPTION
Adding **[QuantumScan](https://quantumscan.io/)** to the `### Standalone` tools section, listed alphabetically between Nipe and sops.

QuantumScan is a free scanner that detects quantum-vulnerable cryptography (RSA, ECDSA, Diffie-Hellman, SHA-1, MD5, etc.) in GitHub repositories. It exports:

- **CycloneDX 1.7 CBOM** (cryptographic-asset inventory recommended by CISA)
- **DORA / NIS2 compliance PDF** aligned with EU regulations active since January 2025
- AI-generated migration guides per finding suggesting NIST FIPS 203/204/205 alternatives

The **scanner core is MIT-licensed** at https://github.com/quantumscan-io/scanner-core — users can audit / self-host the detection logic. The hosted version is free during the design partner phase.

Fits in the standalone tools category alongside `gpg`, `sops`, and `cryptomator` — practical cryptography utilities engineers use day-to-day, not a library implementing primitives.

Following the alphabetical convention of the section.