### PR TITLE
Add Text Machine to Web-tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [CyberChef](https://gchq.github.io/CyberChef/) - a web app for encryption, encoding, compression, and data analysis.
 - [factordb.com](http://factordb.com/) - Factordb.com is tool used to store known factorizations of any number.
 - [keybase.io](https://keybase.io/) - Keybase maps your identity to your public keys, and vice versa.
+- [Text Machine](https://textmachine.org/) - Free, in-browser encoders/decoders for classical ciphers (Caesar and Vigenère through Bazeries, Chaocipher, and the Straddling Checkerboard); fully client-side, no signup.
 
 ### Web-sites
 


### PR DESCRIPTION
Adds [Text Machine](https://textmachine.org/) to the **Web-tools** section.

It's a free, fully client-side site of classical-cipher encoders/decoders — Caesar and Vigenère through harder-to-find ones like Bazeries, Chaocipher, and the Straddling Checkerboard. Same category as the already-listed **CyberChef** and **Boxentriq** (browser-based code-breaking tools). No signup, nothing is uploaded.

- One link, placed alphabetically in Web-tools
- Non-promotional description, matching the list's style