### PR TITLE
Add WTX

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [sodiumoxide](https://github.com/dnaq/sodiumoxide) - Sodium Oxide: Fast cryptographic library for Rust (bindings to libsodium).
 - [suruga](https://github.com/klutzy/suruga) - TLS 1.2 implementation in Rust.
 - [webpki](https://github.com/briansmith/webpki) - Web PKI TLS X.509 certificate validation in Rust.
+- [wtx](https://github.com/c410-f3r/wtx) - TLS 1.3 client and server implementation
 
 ### Scala
 


### PR DESCRIPTION
`WTX` implements RFC-8446 (https://datatracker.ietf.org/doc/html/rfc8446) as well as RFC-5280 (https://datatracker.ietf.org/doc/html/rfc5280). There are other already included projects related to these RFCs, as such, it seems feasible to also include `WTX`.

`WTX` also has a built-from-scratch `ChaCha20` but it is more associated with hashing than crypto.