### PR TITLE
Add @0xsarwagya/ghost to JavaScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ A curated list of cryptography resources and links.
 
 ### JavaScript
 
+- [@0xsarwagya/ghost](https://oss.sarwagya.wtf/ghost/docs) — Non-extractable Ed25519 CryptoKey in IndexedDB. Challenge/response with server-side verification, opt-in recovery.
 - [asmCrypto](https://github.com/vibornoff/asmcrypto.js/) - JavaScript implementation of popular cryptographic utilities with performance in mind.
 - [bcrypt-Node.js](https://github.com/shaneGirish/bcrypt-Node.js) - Native implementation of bcrypt for Node.js.
 - [cifre](https://github.com/openpeer/cifre) - Fast crypto toolkit for modern client-side JavaScript.


### PR DESCRIPTION
@0xsarwagya/ghost is an MIT-licensed browser identity library. Novel angle: non-extractable Ed25519 CryptoKey persisted via IndexedDB (structured clone of CryptoKey), so the private key material never leaves the browser — not to JS, not to devtools. Author disclosure: I wrote it.