### PR TITLE
Add Bitcoin Quantum Address Checker (Web-tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 
 ### Web-tools
 
+- [Bitcoin Quantum Address Checker](https://infobitcoin.es/quantum-check/) - checks whether a Bitcoin address has its public key already exposed on-chain (the only thing a future quantum computer running Shor's algorithm could attack); runs fully client-side, the address never leaves the browser. EN + ES.
 - [Boxentriq](https://www.boxentriq.com/code-breaking) - Easy to use tools for analysis and code-breaking of the most frequent ciphers, including Vigenère, Beaufort, Keyed Caesar, Transposition Ciphers, etc.
 - [Cryptolab](http://manansingh.github.io/Cryptolab-Offline/cryptolab.html) - is a set of cryptography related tools.
 - [CrypTool](http://www.cryptool-online.org/) - Great variety of ciphers, encryption methods and analysis tools are introduced, often together with illustrated examples.


### PR DESCRIPTION
Adds the InfoBitcoin Bitcoin Quantum Address Checker to Resources > Web-tools (alphabetical position, before Boxentriq).

Why it's awesome: it makes the practical side of the quantum threat to ECDSA tangible. Paste a Bitcoin address and it tells you whether its public key is already visible on-chain - the precondition for a future attack with Shor's algorithm - or still protected behind a hash (P2PKH/P2WPKH never spent), with an explanation of each case (Taproot outputs, key reuse, spent addresses). 100% client-side (static HTML + JS querying the public mempool.space API from the user's browser; the address never touches a server). Free, no sign-up, available in English and Spanish. Source code: https://github.com/optimaquantum/bitcoin-quantum-checker (MIT).

One link, one commit, description ends with a period and is under 350 characters.