### PR TITLE
Add ClawSec to Tools/Standalone

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ A curated list of cryptography resources and links.
 - [Bcrypt](http://bcrypt.sourceforge.net/) - Cross-platform file encryption utility.
 - [blackbox](https://github.com/StackExchange/blackbox) - safely store secrets in Git/Mercurial/Subversion.
 - [certbot](https://github.com/certbot/certbot) - Previously the Let's Encrypt Client, is EFF's tool to obtain certs from Let's Encrypt, and (optionally) auto-enable HTTPS on your server. It can also act as a client for any other CA that uses the ACME protocol.
+- [ClawSec](https://github.com/LF3551/ClawSec) - Encrypted networking toolkit with AES-256-GCM, X25519 and post-quantum hybrid (ML-KEM-768) key exchange, TUN VPN and TLS camouflage.
 - [Coherence](https://github.com/liesware/coherence/) - Cryptographic server for modern web apps.
 - [cryptomator](https://github.com/cryptomator/cryptomator) - Multi-platform transparent client-side encryption of your files in the cloud.
 - [Databunker](https://databunker.org/) - API based personal data or PII storage service built to comply with GDPR and CCPA.


### PR DESCRIPTION
Adds [ClawSec](https://github.com/LF3551/ClawSec) to **Tools → Standalone**.

ClawSec is awesome because it's an open-source encrypted networking toolkit that ships **post-quantum hybrid key exchange (ML-KEM-768)** alongside classic AES-256-GCM + X25519, plus a TUN VPN and TLS camouflage for censorship resistance — a practical, modern PQC tool.

- [x] One link, one commit, one PR
- [x] Format: `- [name](link) - Description.` (ends with a period)
- [x] Inserted alphabetically (between certbot and Coherence)
- [x] No trailing whitespace