### PR TITLE
Add subtlepq (JavaScript)

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ A curated list of cryptography resources and links.
 - [PolyCrypt](https://github.com/polycrypt/polycrypt) - Pure JS implementation of the WebCrypto API.
 - [rusha](https://github.com/srijs/rusha) - High-performance pure-javascript SHA1 implementation suitable for large binary data, reaching up to half the native speed.
 - [sjcl](https://github.com/bitwiseshiftleft/sjcl) - Stanford JavaScript Crypto Library.
+- [subtlepq](https://github.com/vesvault/subtlepq) - Post-quantum polyfill for the Web Cryptography API: ML-KEM and ML-DSA per the WICG modern-algos draft, delegating to native platform support where present, plus a DHKEM (RFC 9180) adapter for ECDH-to-KEM migration.
 - [TweetNaCl.js](https://github.com/dchest/tweetnacl-js) - A port of TweetNaCl / NaCl for JavaScript for modern browsers and Node.js.
 - [URSA](https://github.com/quartzjer/ursa) - RSA public/private key OpenSSL bindings for Node.
 


### PR DESCRIPTION
One entry, one commit: adds subtlepq to the JavaScript section (alphabetically between sjcl and TweetNaCl.js).

Why it's awesome: it's the first polyfill of the WICG Modern Algorithms draft for the Web Cryptography API — ML-KEM (FIPS 203) and ML-DSA (FIPS 204) as `crypto.subtle` algorithms with the draft's new `encapsulateBits`/`encapsulateKey`/`decapsulateBits`/`decapsulateKey`/`getPublicKey`/`supports` methods and the full key-format surface (seeds, SPKI, PKCS#8, JWK `AKP`, wrapKey/unwrapKey). Unlike raw-primitive libraries (noble-post-quantum, already listed), it exposes the standard WebCrypto API shape, delegates per algorithm to native implementations where they exist (Node >= 24.7 has ML-KEM/ML-DSA natively), and self-retires as platforms catch up. It also includes a DHKEM (RFC 9180) adapter over native ECDH so existing ECDH code can move to the KEM calling convention before going post-quantum.

Apache-2.0. Engine is a minimal reproducible liboqs wasm build (75 KB for all six parameter sets). Correctness is anchored to NIST ACVP known-answer vectors, RFC 9180 Appendix A vectors, and a byte-parity suite against Node's native implementation.