### PR TITLE
Add quantakrypto pqc-tools (post-quantum readiness scanner + CBOM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of cryptography resources and links.
 - [gpg](https://www.gnupg.org/) - Complete and free implementation of the OpenPGP standard. It allows to encrypt and sign your data and communication, features a versatile key management system. GnuPG is a command line tool with features for easy integration with other applications.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
+- [quantakrypto pqc-tools](https://quantakrypto.com/tools) - Open-source scanner that inventories quantum-vulnerable cryptography (RSA/ECDH/ECDSA/DH) in code, config and dependencies and emits a CycloneDX CBOM with NIST post-quantum migration guidance. ([source](https://github.com/quantakrypto/pqc-tools))
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
 


### PR DESCRIPTION
Adds **quantakrypto pqc-tools** to Tools → Standalone (alphabetically, between Nipe and sops).

Open-source (Apache-2.0) tool that scans code, config and dependencies for quantum-vulnerable asymmetric cryptography (RSA / ECDH / ECDSA / DH / DSA), builds a CycloneDX CBOM (cryptographic bill of materials), and gives NIST ML-KEM / ML-DSA / SLH-DSA (and hybrid) migration guidance. It also includes a FIPS 203/204/205 conformance battery. Zero runtime dependencies.

- Source: https://github.com/quantakrypto/pqc-tools
- Tools page: https://quantakrypto.com/tools

It's an analysis/inventory tool rather than an encryption utility — happy to move it to a more fitting subsection if you'd prefer. _Disclosure: I'm on the quantakrypto team._