### PR TITLE
Add PGP Tools to encryption tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A curated list of cryptography resources and links.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
+- [PGP Tools](https://github.com/Am-I-Being-Pwned/PGP-Tools) - User friendly PGP in the browser, encryption at rest with Passkeys
 
 ### Plugins
 


### PR DESCRIPTION
Added PGP Tools to the list of encryption tools in the README.

PGP Tools is a UX and security first tool to let users manage public and private keys conveniently. Fully opensource.

[link here](https://github.com/Am-I-Being-Pwned/PGP-Tools)
[published here](https://chromewebstore.google.com/detail/pgp-tools-encrypt-decrypt/pgpcdgggohpbombhkffjoiiafdlfcpgp)