### PR TITLE
Adds `lemon-tls` to the JavaScript section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ A curated list of cryptography resources and links.
 - [crypto-js](https://github.com/brix/crypto-js) - JavaScript library of crypto standards.
 - [cryptojs](https://github.com/gwjjeff/cryptojs) - Provide standard and secure cryptographic algorithms for Node.js.
 - [forge](https://github.com/digitalbazaar/forge) - Native implementation of TLS in JavaScript and tools to write crypto-based and network-heavy webapps.
+* [lemon-tls](https://github.com/colocohen/lemon-tls) - Pure JavaScript TLS 1.3 and DTLS implementation for Node.js, with a node:tls-compatible API and exportable handshake secrets for QUIC.
 - [IronNode](https://docs.ironcorelabs.com/ironnode-sdk/overview) - Transform encryption library, a variant of proxy re-encryption, for encrypting to users or groups, and easily adding strong data controls to Node.js apps.
 - [IronWeb](https://docs.ironcorelabs.com/ironweb-sdk/overview) - Transform encryption library, a variant of proxy re-encryption, for easily managing end-to-end encryption securely in the browser.
 - [javascript-crypto-library](https://github.com/clipperz/javascript-crypto-library) - JavaScript Crypto Library provides web developers with an extensive and efficient set of cryptographic functions.


### PR DESCRIPTION
A pure JavaScript implementation of TLS 1.2, TLS 1.3, DTLS 1.2 and DTLS 1.3 - client and server for each - with an API compatible with Node's built-in `tls` module. No OpenSSL, no native bindings, zero dependencies beyond `node:crypto`.

Includes session resumption (tickets + PSK), HelloRetryRequest, mutual TLS, Key Update, ALPN/SNI, and X25519/P-256/P-384. Verified against Chrome, curl, OpenSSL s_client and Node's own TLS in both roles.

Beyond the standard API it exposes handshake secrets, the record layer and exported keying material (RFC 5705 / RFC 8446 §7.5) - what protocols like QUIC and DTLS-SRTP need and what `node:tls` does not provide. It is the TLS layer behind a QUIC/HTTP3 implementation and a WebRTC stack.

The closest existing entry is forge; lemon-tls covers the modern versions and the DTLS side, and adds the key-access surface.

Apache-2.0.