### PR TITLE
Add Post-quantum reproducibility resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ A curated list of cryptography resources and links.
   - [Mailing lists](#mailing-lists)
   - [Web-tools](#web-tools)
   - [Web-sites](#web-sites)
+  - [Post-quantum reproducibility](#post-quantum-reproducibility)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -473,6 +474,13 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 - [Subreddit of Cryptography](https://www.reddit.com/r/cryptography/) - This subreddit is intended for links and discussions surrounding the theory and practice of strong cryptography.
 - [TikZ for Cryptographers](https://www.iacr.org/authors/tikz/) - A collection of block diagrams of common cryptographic functions drawn in TikZ to be used in research papers and presentations written in LaTeX.
 - [WebCryptoAPI](https://www.w3.org/TR/WebCryptoAPI/) - This specification describes a JavaScript API for performing basic cryptographic operations in web applications, such as hashing, signature generation and verification, and encryption and decryption.
+
+### Post-quantum reproducibility
+
+Independent, reproducible research on post-quantum cryptographic implementations and conformance evidence.
+
+- [QNSI ML-KEM ACVP Reproducibility Study](https://arxiv.org/abs/2608.13784) - Frozen, product-neutral reproducibility protocol evaluating noble-post-quantum, liboqs, and Go against pinned public NIST ML-KEM ACVP vectors, with case-preserving records and frozen comparison-path controls.
+- [QNSI ML-KEM ACVP Research Artifact](https://doi.org/10.5281/zenodo.21910571) - MIT-licensed two-command reproducible artifact for the study, with pinned public sources and SHA-256 digests.
 
 ## Contributing
 


### PR DESCRIPTION
Adds a small 'Post-quantum reproducibility' subsection under Resources with two entries: an independent ML-KEM ACVP reproducibility study (arXiv:2608.13784) and its MIT-licensed reproducible artifact (Zenodo).

Why it is awesome: the list already includes noble-post-quantum and liboqs; this study evaluates those two plus Go against pinned public NIST ML-KEM ACVP vectors with a frozen, falsifiable protocol (case-preserving records, frozen comparison-path controls, audit predicates) and a two-command reproducible artifact. It is reproducible research evidence for the PQC entries already in this list, not a product page.

Disclosure: I am the founder of HEOSSI (QNSI), the organization behind the study and artifact - submitted transparently because the entries are independently verifiable (the artifact reruns in ~2 minutes and any outcome is a result).