### PR TITLE
Add Ombracrypt to Standalone tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ A curated list of cryptography resources and links.
 - [gpg](https://www.gnupg.org/) - Complete and free implementation of the OpenPGP standard. It allows to encrypt and sign your data and communication, features a versatile key management system. GnuPG is a command line tool with features for easy integration with other applications.
 - [ironssh](https://github.com/IronCoreLabs/ironssh) - End-to-end encrypt transferred files using sftp/scp and selectively share with others. Automatic key management works with any SSH server. Encrypted files are gpg compatible.
 - [Nipe](https://github.com/GouveaHeitor/nipe) - Nipe is a script to make Tor Network your default gateway.
+- [Ombracrypt](https://github.com/ABiswasDev/Ombracrypt) - Zero-trust, 100% offline local file encryption utility built with Post-Quantum Cryptography (PQC) with duress passcode
 - [sops](https://github.com/mozilla/sops) - sops is an editor of encrypted files that supports YAML, JSON and BINARY formats and encrypts with AWS KMS, GCP KMS, Azure Key Vault and PGP.
 - [ves](https://ves.host/docs/ves-util) - End-to-end encrypted sharing via cloud repository, secure recovery through a viral network of friends in case of key loss.
 


### PR DESCRIPTION
Adding Ombracrypt to the Standalone tools list in alphabetical order. It is an open-source, offline local file encryption utility built with Post-Quantum Cryptography (PQC). Thank you for reviewing!