### PR TITLE
Add kemproof to PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ encryption library providing MD5, SHA1, SHA2 hashing and HMAC functionality, as 
 ### PHP
 
 - [halite](https://paragonie.com/project/halite) - Simple library for encryption using `libsodium`.
+- [kemproof](https://github.com/langacorp/kemproof) - Attests that an ML-KEM-768 key exchange took place and records it with an expiry. It does not encrypt anything.
 - [libsodium-laravel](https://github.com/scrothers/libsodium-laravel) - Laravel Package Abstraction using `libsodium`.
 - [PHP Encryption](https://github.com/defuse/php-encryption) - Library for encrypting data with a key or password in PHP.
 - [PHP Themis](https://github.com/cossacklabs/themis/wiki/PHP-Howto) - PHP wrapper on Themis. High level crypto library for storing data (AES), secure messaging (ECC + ECDSA / RSA + PSS + PKCS#7) and session-oriented, forward secrecy data exchange (ECDH key agreement, ECC & AES encryption).


### PR DESCRIPTION
### What this adds

`kemproof` — a PHP library that attests an ML-KEM-768 key exchange took place, and records it with an expiry. It does not encrypt anything: the shared secret is used to derive a fingerprint and is then discarded.

**Disclosure: I am the author.** kemproof is built and maintained by LANGA Corporation, and I work there. I am saying so up front rather than letting you find out.

### Why it exists

It came out of a defect on our own estate. Our public pages claimed post-quantum *encryption* where the code performed a *key exchange* — two different promises. Writing the honest version of the claim was the harder half, and the tool is what came out of it: something that records that an exchange happened, and says plainly what that does and does not prove.

That is also why the entry reads the way it does. In a list of encryption libraries, "it does not encrypt anything" looks like an objection. It is the point: this is an attestation, not a channel. If you need protected traffic you need a protocol, not this.

### Checks

- One link, one commit, one pull request.
- Placed alphabetically in the PHP section, between `halite` and `libsodium-laravel`.
- Description is 165 characters, ends with a period, no trailing whitespace.
- `npm test` (remark-lint) passes on this branch. I also ran it the other way: renaming the entry so it falls out of alphabetical order makes the linter fail, so the pass is a real one.
- Searched for a prior entry. The only existing ML-KEM reference is `noble-post-quantum` under JavaScript — a different language and a different thing.

Repository: https://github.com/langacorp/kemproof — MIT, on Packagist as `langacorp/kemproof`, archived on Zenodo with a DOI.

Happy to reword it or drop it if it is not a fit for the list.
